### PR TITLE
Migrate from sentry-raven to sentry-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,39 @@
 PATH
   remote: .
   specs:
-    sentry-jets (0.2.0)
-      sentry-raven
+    sentry-jets (0.4.2)
+      sentry-ruby
 
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.3)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    multipart-post (2.0.0)
-    rake (10.5.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    concurrent-ruby (1.2.2)
+    diff-lcs (1.5.0)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
-    sentry-raven (2.9.0)
-      faraday (>= 0.7.6, < 1.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    sentry-ruby (5.12.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
-  bundler (~> 1.16)
-  rake (~> 10.0)
-  rspec (~> 3.0)
+  bundler (~> 2.4.20)
+  rake (~> 13.0)
+  rspec (~> 3.4)
   sentry-jets!
 
 BUNDLED WITH
-   1.17.3
+   2.4.20

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This gem adds Sentry error reporting support to [Jets: Ruby Serverless Framework](http://rubyonjets.com/).
 
-This gem is not officially associated and written by Sentry. This is written by [tongueroo](https://www.linkedin.com/in/tongueroo/).  Looking for maintainers or someone who would like to see if they can get this integrated to the official [sentry-raven](https://github.com/getsentry/raven-ruby) gem instead. At which point, this gem should be deprecated.
+This gem is not officially associated and written by Sentry. This is written by [tongueroo](https://www.linkedin.com/in/tongueroo/).  Looking for maintainers or someone who would like to see if they can get this integrated to the official [sentry-ruby](https://github.com/getsentry/sentry-ruby) gem instead. At which point, this gem should be deprecated.
 
 ## Installation
 

--- a/lib/sentry_jets/turbine.rb
+++ b/lib/sentry_jets/turbine.rb
@@ -6,7 +6,7 @@ module SentryJets
       Sentry.init do |config|
         config.dsn = ENV['SENTRY_DSN']
         config.environment = ENV['SENTRY_CURRENT_ENV'] || Jets.env.to_s
-        config.traces_sample_rate = ENV['SENTRY_TRACE_SAMPLE_RATE'] || 0.0
+        config.traces_sample_rate = ENV['SENTRY_TRACE_SAMPLE_RATE'].to_f || 0.0
       end
     end
 

--- a/lib/sentry_jets/turbine.rb
+++ b/lib/sentry_jets/turbine.rb
@@ -1,4 +1,4 @@
-require 'sentry-raven'
+require 'sentry-ruby'
 
 module SentryJets
   class Turbine < ::Jets::Turbine

--- a/lib/sentry_jets/turbine.rb
+++ b/lib/sentry_jets/turbine.rb
@@ -6,6 +6,7 @@ module SentryJets
       Sentry.init do |config|
         config.dsn = ENV['SENTRY_DSN']
         config.environment = ENV['SENTRY_CURRENT_ENV'] || Jets.env.to_s
+        config.traces_sample_rate = ENV['SENTRY_TRACE_SAMPLE_RATE'] || 0.0
       end
     end
 

--- a/lib/sentry_jets/turbine.rb
+++ b/lib/sentry_jets/turbine.rb
@@ -3,7 +3,7 @@ require 'sentry-raven'
 module SentryJets
   class Turbine < ::Jets::Turbine
     initializer 'sentry.configure' do
-      Raven.configure do |config|
+      Sentry.init do |config|
         config.dsn = ENV['SENTRY_DSN']
         config.current_environment = ENV['SENTRY_CURRENT_ENV'] || Jets.env.to_s
         config.silence_ready = true
@@ -11,7 +11,7 @@ module SentryJets
     end
 
     on_exception 'sentry.capture' do |exception|
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
     end
   end
 end

--- a/lib/sentry_jets/turbine.rb
+++ b/lib/sentry_jets/turbine.rb
@@ -5,8 +5,7 @@ module SentryJets
     initializer 'sentry.configure' do
       Sentry.init do |config|
         config.dsn = ENV['SENTRY_DSN']
-        config.current_environment = ENV['SENTRY_CURRENT_ENV'] || Jets.env.to_s
-        config.silence_ready = true
+        config.environment = ENV['SENTRY_CURRENT_ENV'] || Jets.env.to_s
       end
     end
 

--- a/lib/sentry_jets/version.rb
+++ b/lib/sentry_jets/version.rb
@@ -1,3 +1,3 @@
 module SentryJets
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/sentry-jets.gemspec
+++ b/sentry-jets.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sentry-raven"
+  spec.add_dependency "sentry-ruby"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 2.4.20"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.4"
 end


### PR DESCRIPTION
I have tested on my branch this is currently sending able to send events to Sentry 


<img width="1169" alt="Screenshot 2023-10-12 at 5 23 03 PM" src="https://github.com/boltops-tools/sentry-jets/assets/17206638/f50cd70f-b07d-40d0-b2a7-670fe3623d18">
